### PR TITLE
Add support for arm64 simulator slice in xcframework

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -31,9 +31,6 @@ MARKETING_VERSION = 0.8.0
 // Build number, PLEASE CHANGE HERE to affect all targets
 CURRENT_PROJECT_VERSION = 3
 
-
-ARCHS = arm64 armv7 x86_64 x86_64h i386
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64
 EXCLUDED_ARCHS[sdk=macosx*] = i386
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx
 

--- a/build.sh
+++ b/build.sh
@@ -22,24 +22,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# 
+#
 # Generates opus_swift.xcframework from opus.xcodeproj.
 # Usage: no parameters, settings mostly defined in xcode project
-# 
+#
 
-opts="SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES" 
+opts="SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES"
 
 dd=./DerivedData
 archivesPath="$dd/Archives"
 generatedPath="Products/Library/Frameworks"
 
-# path and name of intermediatly built frameworks 
-builtPath="$dd/Build/Products" 
+# path and name of intermediatly built frameworks
+builtPath="$dd/Build/Products"
 framework=YbridOpus.framework
 
 rm -rfd $dd
 mkdir -p "$archivesPath"
-mkdir -p "$builtPath" 
+mkdir -p "$builtPath"
 
 pj="-project opus-swift.xcodeproj"
 
@@ -51,7 +51,7 @@ xcodebuild archive $pj -scheme $scheme -destination="iOS" -sdk $platform -derive
 cp -R "$archivesPath/$platform.xcarchive/$generatedPath" "$builtPath/Archive-$platform"
 
 platform=iphonesimulator
-scheme=opus_ios
+scheme=opus_ios_sim
 echo "building for $platform..."
 xcodebuild archive $pj -scheme $scheme -destination="iOS Simulator" -sdk $platform -derivedDataPath $dd \
     -archivePath "$archivesPath/$platform.xcarchive" $opts > "build-$platform.log"
@@ -85,7 +85,7 @@ for entry in $products; do
     cmd="$cmd -framework $builtPath/$entry/$framework "
 done
 cmd="$cmd -output $xcframework"
-#echo "$cmd"
+echo "$cmd"
 $cmd
 
 echo "zip $xcframework including LICENSE file..."

--- a/opus-swift.xcodeproj/project.pbxproj
+++ b/opus-swift.xcodeproj/project.pbxproj
@@ -34,6 +34,14 @@
 		17E5BE4125C93DBF0061F232 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 17E5BE3E25C93DBF0061F232 /* Config.xcconfig */; };
 		17EE837725CBFD79002F15B3 /* opus_swiftPlatformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EE837625CBFD79002F15B3 /* opus_swiftPlatformTests.swift */; };
 		17EE83BA25CC0D47002F15B3 /* YbridOpus.framework in Resources */ = {isa = PBXBuildFile; fileRef = D4D822D41DC9612800946CA2 /* YbridOpus.framework */; };
+		66D4683A287E1F2F0066492E /* opus_swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1718AF2D25CAD81700172099 /* opus_swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66D4683B287E1F2F0066492E /* opus_defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 1732224425F6512100AEC833 /* opus_defines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66D4683C287E1F2F0066492E /* opus_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 1732224325F6512100AEC833 /* opus_types.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66D4683D287E1F2F0066492E /* opus_multistream.h in Headers */ = {isa = PBXBuildFile; fileRef = 1732224225F6512100AEC833 /* opus_multistream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66D4683E287E1F2F0066492E /* opus.h in Headers */ = {isa = PBXBuildFile; fileRef = 1732224125F6512100AEC833 /* opus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66D4683F287E1F2F0066492E /* opus_projection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1732224525F6512100AEC833 /* opus_projection.h */; };
+		66D46841287E1F2F0066492E /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 17E5BE3E25C93DBF0061F232 /* Config.xcconfig */; };
+		66D46847287E20060066492E /* libopus_ios_sim.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 66D46833287E1EED0066492E /* libopus_ios_sim.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +80,8 @@
 		17EE827F25CBF086002F15B3 /* opus-swiftMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "opus-swiftMacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		17EE836325CBFD1B002F15B3 /* opus-swiftIOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "opus-swiftIOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		17EE837625CBFD79002F15B3 /* opus_swiftPlatformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = opus_swiftPlatformTests.swift; sourceTree = "<group>"; };
+		66D46833287E1EED0066492E /* libopus_ios_sim.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libopus_ios_sim.a; sourceTree = "<group>"; };
+		66D46845287E1F2F0066492E /* YbridOpus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YbridOpus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4D822D41DC9612800946CA2 /* YbridOpus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YbridOpus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -103,6 +113,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66D46837287E1F2F0066492E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66D46847287E20060066492E /* libopus_ios_sim.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,6 +162,7 @@
 		1732228825F6662A00AEC833 /* libs */ = {
 			isa = PBXGroup;
 			children = (
+				66D46833287E1EED0066492E /* libopus_ios_sim.a */,
 				1732228925F6662A00AEC833 /* libopus_ios.a */,
 				1732228A25F6662A00AEC833 /* libopus_catalyst.a */,
 				1732228B25F6662A00AEC833 /* libopus_osx.a */,
@@ -186,6 +205,7 @@
 				1725464125BE0DC8004EC45A /* YbridOpus.framework */,
 				17EE827F25CBF086002F15B3 /* opus-swiftMacTests.xctest */,
 				17EE836325CBFD1B002F15B3 /* opus-swiftIOSTests.xctest */,
+				66D46845287E1F2F0066492E /* YbridOpus.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -216,6 +236,19 @@
 				1732224A25F6512100AEC833 /* opus_multistream.h in Headers */,
 				1732224725F6512100AEC833 /* opus.h in Headers */,
 				1732225325F6512100AEC833 /* opus_projection.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66D46839287E1F2F0066492E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66D4683A287E1F2F0066492E /* opus_swift.h in Headers */,
+				66D4683B287E1F2F0066492E /* opus_defines.h in Headers */,
+				66D4683C287E1F2F0066492E /* opus_types.h in Headers */,
+				66D4683D287E1F2F0066492E /* opus_multistream.h in Headers */,
+				66D4683E287E1F2F0066492E /* opus.h in Headers */,
+				66D4683F287E1F2F0066492E /* opus_projection.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,6 +340,24 @@
 			productReference = 17EE836325CBFD1B002F15B3 /* opus-swiftIOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		66D46835287E1F2F0066492E /* opus_ios_sim */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66D46842287E1F2F0066492E /* Build configuration list for PBXNativeTarget "opus_ios_sim" */;
+			buildPhases = (
+				66D46836287E1F2F0066492E /* Sources */,
+				66D46837287E1F2F0066492E /* Frameworks */,
+				66D46839287E1F2F0066492E /* Headers */,
+				66D46840287E1F2F0066492E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = opus_ios_sim;
+			productName = opus;
+			productReference = 66D46845287E1F2F0066492E /* YbridOpus.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D4D822D31DC9612800946CA2 /* opus_ios */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D4D822DC1DC9612800946CA2 /* Build configuration list for PBXNativeTarget "opus_ios" */;
@@ -336,24 +387,27 @@
 				ORGANIZATIONNAME = "Viv Labs, Inc.";
 				TargetAttributes = {
 					1725463225BE0DC8004EC45A = {
-						DevelopmentTeam = PF7PNM95XY;
+						DevelopmentTeam = 7J4U792NQT;
 					};
 					1762BBB125B81D180045655C = {
-						DevelopmentTeam = PF7PNM95XY;
+						DevelopmentTeam = 7J4U792NQT;
 						LastSwiftMigration = 1230;
 					};
 					17EE827E25CBF086002F15B3 = {
 						CreatedOnToolsVersion = 12.4;
-						DevelopmentTeam = PF7PNM95XY;
+						DevelopmentTeam = 7J4U792NQT;
 						ProvisioningStyle = Automatic;
 					};
 					17EE835925CBFD1B002F15B3 = {
-						DevelopmentTeam = PF7PNM95XY;
+						DevelopmentTeam = 7J4U792NQT;
 						ProvisioningStyle = Automatic;
+					};
+					66D46835287E1F2F0066492E = {
+						DevelopmentTeam = 7J4U792NQT;
 					};
 					D4D822D31DC9612800946CA2 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = PF7PNM95XY;
+						DevelopmentTeam = 7J4U792NQT;
 						LastSwiftMigration = 1230;
 						ProvisioningStyle = Automatic;
 					};
@@ -373,6 +427,7 @@
 			projectRoot = "";
 			targets = (
 				D4D822D31DC9612800946CA2 /* opus_ios */,
+				66D46835287E1F2F0066492E /* opus_ios_sim */,
 				1762BBB125B81D180045655C /* opus_macos */,
 				1725463225BE0DC8004EC45A /* opus_catalyst */,
 				17EE827E25CBF086002F15B3 /* opus-swiftMacTests */,
@@ -410,6 +465,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				17EE83BA25CC0D47002F15B3 /* YbridOpus.framework in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66D46840287E1F2F0066492E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66D46841287E1F2F0066492E /* Config.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -454,6 +517,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		66D46836287E1F2F0066492E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D4D822CF1DC9612800946CA2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -486,7 +556,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -503,7 +573,7 @@
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;
@@ -522,7 +592,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -539,7 +609,7 @@
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;
@@ -557,7 +627,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -574,7 +644,7 @@
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;
@@ -593,7 +663,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -610,7 +680,7 @@
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = NO;
@@ -627,7 +697,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "opus-swiftUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -650,7 +720,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "opus-swiftUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -670,7 +740,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "opus-swiftUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path";
@@ -697,7 +767,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "opus-swiftUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path";
@@ -709,6 +779,76 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swiftUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		66D46843287E1F2F0066492E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 17E5BE3E25C93DBF0061F232 /* Config.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../dependencies/lib";
+				INFOPLIST_FILE = "opus-swift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/opus/libs",
+					"$(PROJECT_DIR)/opus-swift/libs",
+				);
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
+				PRODUCT_NAME = "$(inherited)";
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		66D46844287E1F2F0066492E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 17E5BE3E25C93DBF0061F232 /* Config.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../dependencies/lib";
+				INFOPLIST_FILE = "opus-swift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/opus/libs",
+					"$(PROJECT_DIR)/opus-swift/libs",
+				);
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
+				PRODUCT_NAME = "$(inherited)";
+				SKIP_INSTALL = NO;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -851,7 +991,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -867,7 +1007,7 @@
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
@@ -884,7 +1024,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = PF7PNM95XY;
+				DEVELOPMENT_TEAM = 7J4U792NQT;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -899,7 +1039,7 @@
 				);
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				OTHER_LDFLAGS = "-all_load";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.ybrid.opus-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "im.vector.opus-swift";
 				PRODUCT_NAME = "$(inherited)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
@@ -941,6 +1081,15 @@
 			buildConfigurations = (
 				17EE836125CBFD1B002F15B3 /* Debug */,
 				17EE836225CBFD1B002F15B3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		66D46842287E1F2F0066492E /* Build configuration list for PBXNativeTarget "opus_ios_sim" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				66D46843287E1F2F0066492E /* Debug */,
+				66D46844287E1F2F0066492E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/opus-swift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/opus-swift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/opus-swift.xcodeproj/xcshareddata/xcschemes/opus_ios_sim.xcscheme
+++ b/opus-swift.xcodeproj/xcshareddata/xcschemes/opus_ios_sim.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "66D46835287E1F2F0066492E"
+               BuildableName = "YbridOpus.framework"
+               BlueprintName = "opus_ios_sim"
+               ReferencedContainer = "container:opus-swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "66D46835287E1F2F0066492E"
+            BuildableName = "YbridOpus.framework"
+            BlueprintName = "opus_ios_sim"
+            ReferencedContainer = "container:opus-swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
The simulator on Apple Silicon Mac's use arm64 architecture. To support both the device and simulator with arm64 opus needs to be built as separate libraries(probably should anyway as device and sim are considered separate platforms). 

A new target was then added to the project and a simulator slice added to the xcFramework.